### PR TITLE
Set type to 'drupal-module'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "lullabot/entity_browser_block_layout",
   "description": "Adjustments to make it easier to use Entity Browser blocks in layout builder.",
-  "type": "drupal-custom-module",
+  "type": "drupal-module",
   "homepage": "https://github.com/Lullabot/entity_browser_block_layout",
   "keywords": ["Drupal"],
   "require": {


### PR DESCRIPTION
In composer.json, the 'type' key should be set to 'drupal-module'.